### PR TITLE
Fixed Access-Control-Max-Age header

### DIFF
--- a/config/cors.js
+++ b/config/cors.js
@@ -80,7 +80,7 @@ module.exports = {
   | MaxAge
   |--------------------------------------------------------------------------
   |
-  | Define Access-Control-Allow-Max-Age
+  | Define Access-Control-Max-Age
   |
   */
   maxAge: 90

--- a/src/Cors/index.js
+++ b/src/Cors/index.js
@@ -238,7 +238,7 @@ class Cors {
   }
 
   /**
-   * Set `Access-Control-Allow-Max-Age` header only when `maxAge`
+   * Set `Access-Control-Max-Age` header only when `maxAge`
    * is defined inside the config file.
    *
    * @method _setMaxAge
@@ -249,7 +249,7 @@ class Cors {
    */
   _setMaxAge (response) {
     if (this.options.maxAge) {
-      response.header('Access-Control-Allow-Max-Age', this.options.maxAge)
+      response.header('Access-Control-Max-Age', this.options.maxAge)
     }
     return this
   }

--- a/test/cors.spec.js
+++ b/test/cors.spec.js
@@ -278,7 +278,7 @@ test.group('Cors', () => {
       }
     }
     cors._setMaxAge(response)
-    assert.deepEqual(response.headers, { key: 'Access-Control-Allow-Max-Age', value: 90 })
+    assert.deepEqual(response.headers, { key: 'Access-Control-Max-Age', value: 90 })
   })
 
   test('do not set specific headers when request is not options', async (assert) => {
@@ -353,7 +353,7 @@ test.group('Cors', () => {
       { key: 'Access-Control-Allow-Credentials', value: true },
       { key: 'Access-Control-Allow-Methods', value: 'GET,PUT,POST' },
       { key: 'Access-Control-Allow-Headers', value: 'Authorization' },
-      { key: 'Access-Control-Allow-Max-Age', value: 90 },
+      { key: 'Access-Control-Max-Age', value: 90 },
       { key: 'Content-length', value: 0 }
     ])
     assert.equal(response._status, 204)


### PR DESCRIPTION
The name for this header was wrong. The name is `Access-Control-Max-Age` instead of `Access-Control-Allow-Max-Age`.

This PR renames the header field to the correct name.

Reference: 
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Max-Age
