### PR TITLE
Feature/options allow body

### DIFF
--- a/src/Cors/index.js
+++ b/src/Cors/index.js
@@ -272,20 +272,16 @@ class Cors {
       ._setExposeHeaders(response)
 
     /**
-     * If request is not for OPTIONS call next. Otherwise set
-     * CORS headers.
+     * If request is OPTIONS set CORS headers before call next.
      */
-    if (request.method() !== 'OPTIONS') {
-      await next()
-      return
+    if (request.method() === 'OPTIONS') {
+      this
+        ._setMethods(response)
+        ._setHeaders(request.header('access-control-request-headers'), response)
+        ._setMaxAge(response)
     }
 
-    this
-      ._setMethods(response)
-      ._setHeaders(request.header('access-control-request-headers'), response)
-      ._setMaxAge(response)
-
-    response.header('Content-length', 0).status(204).send('')
+    return next()
   }
 }
 

--- a/test/cors.spec.js
+++ b/test/cors.spec.js
@@ -353,10 +353,8 @@ test.group('Cors', () => {
       { key: 'Access-Control-Allow-Credentials', value: true },
       { key: 'Access-Control-Allow-Methods', value: 'GET,PUT,POST' },
       { key: 'Access-Control-Allow-Headers', value: 'Authorization' },
-      { key: 'Access-Control-Max-Age', value: 90 },
-      { key: 'Content-length', value: 0 }
+      { key: 'Access-Control-Max-Age', value: 90 }
     ])
-    assert.equal(response._status, 204)
   })
 
   test('set vary header when options.origin is a string', async (assert) => {


### PR DESCRIPTION
## Proposed changes

CORS Middleware don't send empty response when http method is OPTIONS
Linked with https://github.com/adonisjs/adonis-cors/issues/13

## Types of changes

- Edit handle middleware function
- Fix test `set all cors headers when request is options` no more relevant with allowing body in response

_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

I'm not sure for breaking change, but I don't think so.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [X] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [X] Lint and unit tests pass locally with my changes
- [X] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)